### PR TITLE
FIX: 수강 컨트롤러 수정

### DIFF
--- a/withSchool/src/main/java/com/withSchool/controller/user/SugangController.java
+++ b/withSchool/src/main/java/com/withSchool/controller/user/SugangController.java
@@ -51,7 +51,7 @@ public class SugangController {
 
     @GetMapping("/{subjectId}/scores")
     @Operation(summary = "학생 개인의 성적을 확인하는 데 쓰이는 API")
-    public ResponseEntity<ResStudentSubjectDefaultDTO> findOnesScore(@PathVariable Long subjectId, @RequestParam Long childId) {
+    public ResponseEntity<ResStudentSubjectDefaultDTO> findOnesScore(@PathVariable Long subjectId, @RequestParam(required = false) Long childId) {
         return ResponseEntity.ok().body(studentSubjectService.findOnesScore(subjectId, childId));
     }
 


### PR DESCRIPTION
1. GET /sugangs/{subjectId}/scores 학부모의 자식 성적 조회를 위한 childId request param 추가
2. request param의 required 제거