### PR TITLE
FIX: 어드민의 학생 추가 로직 수정

### DIFF
--- a/withSchool/src/main/java/com/withSchool/entity/school/SchoolApplication.java
+++ b/withSchool/src/main/java/com/withSchool/entity/school/SchoolApplication.java
@@ -45,17 +45,18 @@ public class SchoolApplication extends BaseEntity {
 
     @Comment("""
             서비스 타입
-            
+                        
             0 ~ 2(월간)
-            0 - 소규모
-            1 - 중규모
-            2 - 대규모
-            
+            0 - 소규모(300명)
+            1 - 중규모(500명)
+            2 - 대규모(700명)
+                        
             3 ~ 5(연간)
             3 - 소규모
             4 - 중규모
             5 - 대규모
             """)
+    @Column(columnDefinition = "int default 0")
     private int serviceType;
 
     public ResApplicationDefaultDTO toResApplicationDefaultDTO(){

--- a/withSchool/src/main/java/com/withSchool/entity/school/SchoolInformation.java
+++ b/withSchool/src/main/java/com/withSchool/entity/school/SchoolInformation.java
@@ -126,7 +126,23 @@ public class SchoolInformation extends BaseEntity {
             결제 상태
             0 - 결제 안됨
             1 - 결제 됨""")
-    @Column(columnDefinition = "int default 0")
+    @Column(columnDefinition = "int default 1")
     private int paymentState;
+
+    @Comment("""
+            서비스 타입
+                        
+            0 ~ 2(월간)
+            0 - 소규모(300명)
+            1 - 중규모(500명)
+            2 - 대규모(700명)
+                        
+            3 ~ 5(연간)
+            3 - 소규모
+            4 - 중규모
+            5 - 대규모
+            """)
+    @Column(columnDefinition = "int default 0")
+    private int serviceType;
 
 }

--- a/withSchool/src/main/java/com/withSchool/repository/user/UserRepository.java
+++ b/withSchool/src/main/java/com/withSchool/repository/user/UserRepository.java
@@ -38,6 +38,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findAllBySchoolInformation_SchoolId(Long schoolId);
 
+    List<User> findAllBySchoolInformation_SchoolIdAndAccountTypeNot(Long schoolId, int accountType);
+
     List<User> findAllByClassInformation_ClassId(Long classId);
 
     @Query("SELECT u FROM User u WHERE u.schoolInformation.schoolId = :schoolId AND u.accountType = 0")

--- a/withSchool/src/main/java/com/withSchool/service/csv/CsvService.java
+++ b/withSchool/src/main/java/com/withSchool/service/csv/CsvService.java
@@ -40,6 +40,10 @@ public class CsvService {
     public void registerUser(CsvRequestDTO dto) throws RuntimeException{
         try (CSVReader csvReader = new CSVReader(new InputStreamReader(dto.getFile().getInputStream(),"euc-kr"))) {
             List<String[]> lines = csvReader.readAll();
+
+            int inputUserCount = lines.size() - 1;
+            if(!userService.isEnoughUserRemain(inputUserCount)) throw new RuntimeException("too many user input");
+
             Long schoolId = userService.getCurrentUserSchoolId();
             lines.stream()
                     .skip(1)

--- a/withSchool/src/main/java/com/withSchool/service/user/UserService.java
+++ b/withSchool/src/main/java/com/withSchool/service/user/UserService.java
@@ -293,7 +293,23 @@ public class UserService {
         return userRepository.findStudentByClassId(schoolId);
     }
 
+    public boolean isEnoughUserRemain(int inputSize) {
+        SchoolInformation currentUserSchool = getCurrentUserSchoolInformation(null);
+        List<User> specificSchoolUser = userRepository.findAllBySchoolInformation_SchoolIdAndAccountTypeNot(currentUserSchool.getSchoolId(), 4);
+
+        int userLimit = 0;
+        if(currentUserSchool.getServiceType() == 0) userLimit = 300;
+        else if(currentUserSchool.getServiceType() == 1) userLimit = 500;
+        else if(currentUserSchool.getServiceType() == 2) userLimit = 700;
+
+        int specificSchoolUserCount = specificSchoolUser.size();
+
+        return userLimit - specificSchoolUserCount >= inputSize;
+    }
+
     public void addOneUser(ReqUserRegisterDTO reqUserRegisterDTO) {
+        if(!this.isEnoughUserRemain(1)) throw new RuntimeException("too many user input");
+
         int accountType = reqUserRegisterDTO.getType().equals("학생") ? 0 : 2;
         String name = reqUserRegisterDTO.getName();
         String birthDate = reqUserRegisterDTO.getBirthDate();


### PR DESCRIPTION
1. 유저를 추가 할 때 (현재 플랜의 최대 인원 수 - 현재 학교에 등록 된 인원수) = 추가 등록할 수 있는 인원수가 새로 등록될 인원수보다 적을 때만 추가 가능